### PR TITLE
Fix for proper api usage

### DIFF
--- a/EnLock/EnExtention.cs
+++ b/EnLock/EnExtention.cs
@@ -79,7 +79,7 @@ namespace EnLock
                                     },
                                     TransactionScopeAsyncFlowOption.Enabled))
             {
-                result = await query.FirstOrDefaultAsync(cancellationToken);
+                result = await query.FirstAsync(cancellationToken);
                 scope.Complete();
             }
             return result;

--- a/EnLock/EnExtention.cs
+++ b/EnLock/EnExtention.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -65,6 +67,21 @@ namespace EnLock
                                     TransactionScopeAsyncFlowOption.Enabled))
             {
                 result = await query.FirstOrDefaultAsync(cancellationToken);
+                scope.Complete();
+            }
+            return result;
+        }
+        public static async Task<T> ToFirstOrDefaultWithNoLockAsync<T>(this IQueryable<T> query, Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default)
+        {
+            T result = default;
+            using (var scope = new TransactionScope(TransactionScopeOption.Required,
+                                    new TransactionOptions()
+                                    {
+                                        IsolationLevel = System.Transactions.IsolationLevel.ReadUncommitted
+                                    },
+                                    TransactionScopeAsyncFlowOption.Enabled))
+            {
+                result = await query.FirstOrDefaultAsync(predicate, cancellationToken);
                 scope.Complete();
             }
             return result;


### PR DESCRIPTION
Hi Enis,

In case of using First/Single apis you need to wait for getting an exception(if I'm not wrong it should be InvalidOperationException) not default value of related item. You can refer Enumarable.cs from dotnet source for further usage please follow that [link](https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/System.Core/System/Linq/Enumerable.cs#L1056-L1077). 

P.S: I want to mention that ToFirstOrDefaultWithNoLockAsync/ToFirstWithNoLockAsync naming is not the way dotnet devs used to. Single/First/SingleOrDefault/FirstOrDefault ... do not have any To prefix and I strongly recommend you to follow same convention, but aim of this PR is not that.

Have a great year and happy coding,
O.T.
